### PR TITLE
MAM-40 FE: 필터링 API 연동

### DIFF
--- a/src/hooks/@server/store.ts
+++ b/src/hooks/@server/store.ts
@@ -14,6 +14,8 @@ export const useGetNearbyStoreQuery = (
         params.minLongitude,
         params.maxLongitude,
       ].every(Boolean),
+      params.category,
+      params.isOpen,
     ],
     queryFn: () => getNearbyStore(params),
     placeholderData: {

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -54,19 +54,19 @@ const MainPage = () => {
     },
     option: { isPopupOpen: boolean } = { isPopupOpen: true }
   ) => {
-    setSearchParams(
-      (prev) => {
-        prev.set("minLatitude", bounds.minLatitude.toString());
-        prev.set("maxLatitude", bounds.maxLatitude.toString());
-        prev.set("minLongitude", bounds.minLongitude.toString());
-        prev.set("maxLongitude", bounds.maxLongitude.toString());
-        if (!option.isPopupOpen) {
-          prev.delete("isPopupOpen");
-        }
-        return prev;
-      },
-      { replace: true }
-    );
+    // 현재 URL의 모든 파라미터를 가져와서 새로운 URLSearchParams 생성
+    const newParams = new URLSearchParams(window.location.search);
+
+    newParams.set("minLatitude", bounds.minLatitude.toString());
+    newParams.set("maxLatitude", bounds.maxLatitude.toString());
+    newParams.set("minLongitude", bounds.minLongitude.toString());
+    newParams.set("maxLongitude", bounds.maxLongitude.toString());
+
+    if (!option.isPopupOpen) {
+      newParams.delete("isPopupOpen");
+    }
+
+    setSearchParams(newParams, { replace: true });
   };
 
   const {
@@ -85,8 +85,8 @@ const MainPage = () => {
     lastStoreId: 0,
     category: searchParams.getAll("categories").join(","),
     isOpen: searchParams.get("isOpen") === "true" ? true : undefined,
-    minPrice: 0,
-    maxPrice: 10000000,
+    // minPrice: 0,
+    // maxPrice: 10000000,
   });
 
   const navigate = useNavigate();

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -84,7 +84,7 @@ const MainPage = () => {
     lastDistance: 0,
     lastStoreId: 0,
     category: searchParams.getAll("categories").join(","),
-    isOpen: searchParams.has("isOpen"),
+    isOpen: searchParams.get("isOpen") === "true" ? true : undefined,
     minPrice: 0,
     maxPrice: 10000000,
   });

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -80,9 +80,13 @@ const MainPage = () => {
     maxLatitude: 지도_모서리.maxLatitude,
     minLongitude: 지도_모서리.minLongitude,
     maxLongitude: 지도_모서리.maxLongitude,
-    size: 10,
+    size: 20,
     lastDistance: 0,
     lastStoreId: 0,
+    category: searchParams.getAll("categories").join(","),
+    isOpen: searchParams.has("isOpen"),
+    // minPrice: 0,
+    // maxPrice: 0,
   });
 
   const navigate = useNavigate();

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -85,8 +85,8 @@ const MainPage = () => {
     lastStoreId: 0,
     category: searchParams.getAll("categories").join(","),
     isOpen: searchParams.has("isOpen"),
-    // minPrice: 0,
-    // maxPrice: 0,
+    minPrice: 0,
+    maxPrice: 10000000,
   });
 
   const navigate = useNavigate();


### PR DESCRIPTION
### 변경 사항 요약

- hooks: `useGetNearbyStoreQuery`의 queryKey에 `category`, `isOpen` 추가로 캐시 키 정밀도 향상
- main 페이지: 지도 바운더리 파라미터 동기화 로직 개선 (기존 `setSearchParams` → 기존 파라미터 보존 후 갱신)
- 목록 요청 파라미터 조정: `size` 10 → 20 확장, `category`, `isOpen` 파라미터 전달 추가
- URL 파라미터 처리: `categories`를 `,`로 병합하여 쿼리 전달, `isOpen`을 boolean으로 파싱

### 영향 범위

- 근처 가게 조회 API 캐시 구분이 강화되어 필터 조합 변경 시 데이터가 정확히 갱신됩니다.
- URL 파라미터 유지/갱신 로직 개선으로 사용자가 설정한 다른 쿼리스트링이 의도치 않게 사라지지 않습니다.
- 기본 페이지네이션/페이지 사이즈 증가로 초기 목록이 더 넉넉하게 표시됩니다.

### 테스트 노트

- `categories`를 여러 개 선택한 뒤 지도 범위를 이동하면, 요청 파라미터에 `category=a,b,c` 형태로 전달되는지 확인
- `isOpen=true` 설정 시 닫힌 가게가 목록에서 제외되는지 확인
- 팝업 닫기 옵션(`isPopupOpen=false`)일 때 URL에서 해당 키가 제거되는지 확인

### 관련 이슈
- MAM-40: 필터링 API 연동