### PR TITLE
ci: 배포/이슈 해결 디스코드 알림 추가

### DIFF
--- a/.github/workflows/discord-issue-notify.yml
+++ b/.github/workflows/discord-issue-notify.yml
@@ -1,0 +1,39 @@
+name: Discord Issue Notification
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL 시크릿이 없어 알림을 건너뜁니다."
+            exit 0
+          fi
+          jq -n \
+            --arg title "✅ 이슈 해결: #$ISSUE_NUMBER" \
+            --arg desc "$ISSUE_TITLE" \
+            --arg issue_url "$ISSUE_URL" \
+            --arg actor "$ACTOR" \
+            '{
+              embeds: [{
+                title: $title,
+                description: $desc,
+                url: $issue_url,
+                color: 3447003,
+                fields: [
+                  { name: "처리자", value: $actor, inline: true }
+                ]
+              }]
+            }' | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -52,3 +52,35 @@ jobs:
           cache: "0"
           # Sets the Cache-Control header to immutable
           immutable: true
+
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          ACTOR: ${{ github.actor }}
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL 시크릿이 없어 알림을 건너뜁니다."
+            exit 0
+          fi
+          jq -n \
+            --arg title "🚀 프로덕션 배포 완료" \
+            --arg desc "$(echo "$COMMIT_MESSAGE" | head -1)" \
+            --arg branch "$BRANCH" \
+            --arg actor "$ACTOR" \
+            --arg run_url "$RUN_URL" \
+            '{
+              embeds: [{
+                title: $title,
+                description: $desc,
+                color: 5763719,
+                fields: [
+                  { name: "브랜치", value: $branch, inline: true },
+                  { name: "배포자", value: $actor, inline: true },
+                  { name: "링크", value: ("[사이트](https://mamma-mia.site) · [배포 로그](" + $run_url + ")") }
+                ]
+              }]
+            }' | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## 개요
디스코드 채널로 아래 두 가지 알림을 보내는 CI 워크플로우를 추가합니다.

1. **배포 알림** — `Deploy to S3` 워크플로우 성공 시, 커밋 메시지·브랜치·배포자·사이트/로그 링크를 embed로 전송
2. **이슈 해결 알림** — 이슈가 closed 될 때 이슈 번호·제목·처리자를 embed로 전송

## 설정 필요
- 리포지토리 시크릿 `DISCORD_WEBHOOK_URL` 등록 필요 (디스코드 채널 → 설정 → 연동 → 웹훅)
- 시크릿이 없으면 알림 스텝은 조용히 건너뛰므로 배포에는 영향 없음

## 비고
- 커밋 메시지/이슈 제목은 env → jq 로 전달해 특수문자·인젝션에 안전하게 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)