### PR TITLE
fix: 프로덕션 결함 4건 수정 (빈 상태 UI, 무효 API 요청, 휴무 표시)

### DIFF
--- a/src/hooks/@server/store.ts
+++ b/src/hooks/@server/store.ts
@@ -35,6 +35,13 @@ export const useGetNearbyStoreQuery = (
       params.maxPrice,
     ],
     queryFn: () => getNearbyStore(params),
+    // 지도 초기화 전 bounds가 0인 상태로 무효 요청이 나가지 않도록 방지
+    enabled: [
+      params.minLatitude,
+      params.maxLatitude,
+      params.minLongitude,
+      params.maxLongitude,
+    ].every(Boolean),
     placeholderData: {
       items: [],
       totalCount: 0,

--- a/src/pages/challenge/restaurant/_components/RestaurantBusinessHour.tsx
+++ b/src/pages/challenge/restaurant/_components/RestaurantBusinessHour.tsx
@@ -11,7 +11,9 @@ const RestaurantBusinessHour = ({
   return (
     <>
       {businessHour?.dayOfWeek && DAY_OF_WEEK[businessHour.dayOfWeek].ko}{" "}
-      {[businessHour?.openTime, businessHour?.closeTime].every(Boolean) ? (
+      {businessHour?.isClosed ? (
+        "휴무"
+      ) : [businessHour?.openTime, businessHour?.closeTime].every(Boolean) ? (
         <>
           {businessHour?.openTime} ~ {businessHour?.closeTime}
         </>

--- a/src/pages/ranking/index.tsx
+++ b/src/pages/ranking/index.tsx
@@ -9,6 +9,9 @@ import { useGetRankingQuery } from "@/hooks/@server/store"
 import BottomGNB from "@/components/BottomGNB"
 import Spacing from "@/@lib/components/Spacing"
 import { EMPTY_IMAGE_URL } from "@/constants/setting"
+import EmptyIcon from "@/assets/empty_icon.svg?react"
+import THEME from "@/constants/theme"
+import TYPOGRAPHY from "@/constants/typography"
 
 const PERIOD_TYPE = {
   WEEKLY: "WEEKLY",
@@ -52,39 +55,51 @@ const RankingPage = () => {
           css={rankingTextStyle}
         />
         {/* 랭킹 카드 섹션 */}
-        <Swiper
-          css={rankingSectionStyle}
-          loop
-          slidesPerView={3}
-          spaceBetween={-210}
-          centeredSlides
-        >
-          {stores.slice(0, 3).map((restaurant) => (
-            <SwiperSlide key={`${restaurant.storeId}-1`}>
-              <RankingCard restaurant={restaurant} rankingType={period} />
-            </SwiperSlide>
-          ))}
-          {stores.slice(0, 3).map((restaurant) => (
-            <SwiperSlide key={`${restaurant.storeId}-2`}>
-              <RankingCard restaurant={restaurant} rankingType={period} />
-            </SwiperSlide>
-          ))}
-          {stores.slice(0, 3).map((restaurant) => (
-            <SwiperSlide key={`${restaurant.storeId}-3`}>
-              <RankingCard restaurant={restaurant} rankingType={period} />
-            </SwiperSlide>
-          ))}
-          {stores.slice(0, 3).map((restaurant) => (
-            <SwiperSlide key={`${restaurant.storeId}-4`}>
-              <RankingCard restaurant={restaurant} rankingType={period} />
-            </SwiperSlide>
-          ))}
-          {stores.slice(0, 3).map((restaurant) => (
-            <SwiperSlide key={`${restaurant.storeId}-5`}>
-              <RankingCard restaurant={restaurant} rankingType={period} />
-            </SwiperSlide>
-          ))}
-        </Swiper>
+        {stores.length === 0 && (
+          <div css={emptyStateStyle}>
+            <EmptyIcon />
+            <p css={emptyStateTextStyle}>
+              아직 랭킹에 오른 맛집이 없어요.
+              <br />
+              맘마미아 투표로 첫 랭킹을 만들어 보세요!
+            </p>
+          </div>
+        )}
+        {stores.length > 0 && (
+          <Swiper
+            css={rankingSectionStyle}
+            loop
+            slidesPerView={3}
+            spaceBetween={-210}
+            centeredSlides
+          >
+            {stores.slice(0, 3).map((restaurant) => (
+              <SwiperSlide key={`${restaurant.storeId}-1`}>
+                <RankingCard restaurant={restaurant} rankingType={period} />
+              </SwiperSlide>
+            ))}
+            {stores.slice(0, 3).map((restaurant) => (
+              <SwiperSlide key={`${restaurant.storeId}-2`}>
+                <RankingCard restaurant={restaurant} rankingType={period} />
+              </SwiperSlide>
+            ))}
+            {stores.slice(0, 3).map((restaurant) => (
+              <SwiperSlide key={`${restaurant.storeId}-3`}>
+                <RankingCard restaurant={restaurant} rankingType={period} />
+              </SwiperSlide>
+            ))}
+            {stores.slice(0, 3).map((restaurant) => (
+              <SwiperSlide key={`${restaurant.storeId}-4`}>
+                <RankingCard restaurant={restaurant} rankingType={period} />
+              </SwiperSlide>
+            ))}
+            {stores.slice(0, 3).map((restaurant) => (
+              <SwiperSlide key={`${restaurant.storeId}-5`}>
+                <RankingCard restaurant={restaurant} rankingType={period} />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        )}
 
         <div css={css({ padding: "0 20px", marginTop: 96 })}>
           {stores.map((restaurant) => (
@@ -153,3 +168,26 @@ const rankingTextStyle = css({
   transform: "translateX(-50%)",
   zIndex: 1000,
 })
+
+// 빈 상태 스타일
+const emptyStateStyle = css({
+  position: "absolute",
+  top: 180,
+  left: 0,
+  right: 0,
+  zIndex: 1000,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 20,
+  padding: "40px 20px",
+})
+
+const emptyStateTextStyle = css(
+  {
+    textAlign: "center",
+    color: THEME.COLORS.GRAYSCALE.ALTERNATIVE,
+    margin: 0,
+  },
+  TYPOGRAPHY.BODY["14R"]
+)

--- a/src/pages/restaurant/_components/RestaurantBusinessHour.tsx
+++ b/src/pages/restaurant/_components/RestaurantBusinessHour.tsx
@@ -11,7 +11,9 @@ const RestaurantBusinessHour = ({
   return (
     <>
       {businessHour?.dayOfWeek && DAY_OF_WEEK[businessHour.dayOfWeek].ko}{" "}
-      {[businessHour?.openTime, businessHour?.closeTime].every(Boolean) ? (
+      {businessHour?.isClosed ? (
+        "휴무"
+      ) : [businessHour?.openTime, businessHour?.closeTime].every(Boolean) ? (
         <>
           {businessHour?.openTime} ~ {businessHour?.closeTime}
         </>

--- a/src/pages/search/_components/NewRestaurantSection/index.tsx
+++ b/src/pages/search/_components/NewRestaurantSection/index.tsx
@@ -7,7 +7,6 @@ import NewRestaurantCard from "./_components/NewRestaurantCard"
 import { Swiper, SwiperSlide, type SwiperRef } from "swiper/react"
 import VIEWPORT from "@/constants/viewport"
 import { useRef } from "react"
-import { Virtual } from "swiper/modules"
 import { 충무로역_좌표 } from "@/pages/main/_constants"
 import { useGetNearbyStoreQuery } from "@/hooks/@server/store"
 
@@ -25,6 +24,8 @@ const NewRestaurantSection = () => {
     isNew: true,
   })
   const swiperRef = useRef<SwiperRef>(null)
+
+  if (!data?.items.length) return null
 
   return (
     <div css={newRestaurantSectionStyle}>


### PR DESCRIPTION
## 개요
프로덕션(https://mamma-mia.site) 탐색으로 발견한 결함 4건을 수정합니다.

Closes #43
Closes #44
Closes #45
Closes #46

## 변경 사항
| 이슈 | 수정 | 파일 |
|---|---|---|
| #43 | 랭킹 데이터가 없으면 빈 상태 UI(아이콘+안내 문구) 표시, Swiper는 데이터 있을 때만 렌더 | `src/pages/ranking/index.tsx` |
| #44 | NEW 섹션 데이터 없으면 섹션 숨김 (+미사용 Virtual import 제거) | `src/pages/search/_components/NewRestaurantSection/index.tsx` |
| #45 | `useGetNearbyStoreQuery`에 enabled 조건 추가 — bounds 4개가 유효할 때만 요청 | `src/hooks/@server/store.ts` |
| #46 | `isClosed=true`인 요일 "휴무" 표시 (로컬에만 있던 미커밋 수정 반영) | `RestaurantBusinessHour.tsx` ×2 |

## 검증
- 로컬 dev 서버 + prod API로 확인:
  - /ranking → 빈 상태 UI 정상 표시 (주간/월간)
  - /search → NEW 섹션 공백 사라짐
  - / 진입 → `minLatitude=0` 무효 요청 미발생, 유효 bounds 요청만 1건
- `vite build` 통과, prettier 통과
- 참고: `tsc -b`는 main에 이미 존재하는 무관한 타입 에러들로 실패 (배포 파이프라인은 `vite build`만 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)