### PR TITLE
chore: Vercel 배포 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 *storybook.log
 storybook-static
+.vercel
+.env*

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 개요
인프라를 Vercel 배포로 전환하기 위한 설정입니다.

- `vercel.json`: SPA 클라이언트 라우팅용 rewrite (직접 URL 접근 시 404 방지)
- `.gitignore`: `.vercel`, `.env*` 추가

## 배경
- 기존 "Deploy to S3" CI는 성공하지만 실제 mamma-mia.site는 오라클 Caddy 서버가 서빙 중이라 반영이 안 되는 상태였음 (#49 참고 예정)
- Vercel 프로젝트(mamma-mia-frontend)에 프로덕션 배포 완료, mamma-mia.site 도메인 연결됨 (DNS 변경 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)