### PR TITLE
ci: S3 배포를 Vercel 배포로 교체

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,18 +1,17 @@
-name: Deploy to S3
+name: Deploy to Vercel
 
 on:
   push:
     branches:
       - main
-      - stage/*
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      VITE_API_URL: ${{ vars.VITE_API_URL }}
+      VERCEL_ORG_ID: team_lmRUn3mWMp0n48c6H63XidpZ
+      VERCEL_PROJECT_ID: prj_EzcKmcwkrYVbiAy9xlUztngUtEo4
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
@@ -21,37 +20,19 @@ jobs:
         uses: actions/setup-node@v5.0.0
         with:
           node-version: "22.19.0"
-          cache: "yarn"
 
-      - name: Install dependencies
-        run: yarn install
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      # 환경 변수는 Vercel 프로젝트 설정에서 받아온다 (VITE_API_URL, VITE_SENTRY_DSN 등)
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build
-        run: yarn vite build
+        run: vercel build --prod --token="$VERCEL_TOKEN"
 
-      - name: Deploy to S3
-        uses: Reggionick/s3-deploy@v4.0.0
-        with:
-          # Directory to deploy
-          folder: dist
-          # Name of AWS Bucket
-          bucket: ${{ secrets.S3_BUCKET }}
-          # The destination bucket region
-          bucket-region: ${{ secrets.AWS_REGION }}
-          # AWS CloudFront distribution ID
-          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          # AWS CloudFront invalidation path(s)
-          invalidation: "/*"
-          # Removes files in S3 that are not available in the local copy of the directory
-          delete-removed: true
-          # Use this parameter to specify Cache-Control: no-cache, no-store, must-revalidate header
-          no-cache: true
-          # Upload files with private ACL, needed for S3 static website hosting
-          private: true
-          # Sets the Cache-Control: max-age=X header
-          cache: "0"
-          # Sets the Cache-Control header to immutable
-          immutable: true
+      - name: Deploy
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
 
       - name: Notify Discord
         if: success()


### PR DESCRIPTION
## 배경
- S3 + CloudFront는 비용 문제로 **현재 사용하지 않음**. 그런데 워크플로가 main 푸시마다 계속 빌드/업로드/무효화를 수행 중이라 쓰지 않는 AWS 비용이 발생
- 실제 프로덕션(`mamma-mia.site`)은 Vercel이 서빙 중이나, Vercel의 Git 연동이 **개인 fork**에 걸려 있어 조직 repo에 머지해도 배포가 되지 않았음 (PR #51 머지 시 확인)

## 변경
- `production-deployment.yml`을 S3 배포 → **Vercel CLI 배포**로 교체
- Vercel Git 연동(조직 repo 연결 시 Team 플랜 필요) 대신 CLI + 토큰 방식이라 **추가 비용 없음**. public repo라 Actions도 무료
- 빌드 환경 변수는 `vercel pull`로 Vercel 프로젝트 설정에서 가져옴 (`VITE_API_URL`, `VITE_SENTRY_DSN`)
- Discord 배포 알림은 그대로 유지
- 트리거를 `main`으로 한정 (기존 `stage/*`는 프로덕션 배포 대상이 아니라 제외)

## 머지 전 필요한 작업
조직 repo에 시크릿 **`VERCEL_TOKEN`** 추가 필요 (Vercel Account Settings → Tokens에서 발급).
이것 없이 머지하면 배포 job이 실패합니다. Org/Project ID는 비밀값이 아니라 워크플로에 직접 기재.

## 머지 후 정리 가능한 항목
- 조직 repo 시크릿: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `CLOUDFRONT_DISTRIBUTION_ID` (더 이상 미사용)
- AWS 쪽 S3 버킷 / CloudFront 배포본 자체 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn3WFctS711j4Y6JAc5UeR