### PR TITLE
fix(ci): Vercel 명령에 팀 스코프 명시

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -26,13 +26,13 @@ jobs:
 
       # 환경 변수는 Vercel 프로젝트 설정에서 받아온다 (VITE_API_URL, VITE_SENTRY_DSN 등)
       - name: Pull Vercel environment
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        run: vercel pull --yes --environment=production --scope=shackstacks-projects --token="$VERCEL_TOKEN"
 
       - name: Build
-        run: vercel build --prod --token="$VERCEL_TOKEN"
+        run: vercel build --prod --scope=shackstacks-projects --token="$VERCEL_TOKEN"
 
       - name: Deploy
-        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        run: vercel deploy --prebuilt --prod --scope=shackstacks-projects --token="$VERCEL_TOKEN"
 
       - name: Notify Discord
         if: success()


### PR DESCRIPTION
PR #52 머지 후 배포 job이 `Error: Could not retrieve Project Settings`로 실패.

로컬에서 동일한 env-var 링크 방식(`VERCEL_ORG_ID` + `VERCEL_PROJECT_ID`)을 재현했을 때는 정상 동작 → 워크플로 문법 문제가 아니라 토큰이 팀(`shackstacks-projects`) 스코프로 해석되지 않는 문제로 판단.

`--scope=shackstacks-projects`를 세 개 명령에 명시.

이후에도 같은 에러가 나면 토큰 자체가 개인 계정 스코프로 발급된 것이므로, `shackstacks-projects` 팀 접근 권한이 있는 토큰으로 재발급 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn3WFctS711j4Y6JAc5UeR