### PR TITLE
refactor: Kakao JavaScript 키를 환경 변수로 분리

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta property="og:url" content="https://mamma-mia.site" />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=80d903717b077cbc441742dd63bffb7e&libraries=services"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_JS_KEY%&libraries=services"
     ></script>
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.6/kakao.min.js"
@@ -26,7 +26,7 @@
       crossorigin="anonymous"
     ></script>
     <script>
-      Kakao.init("519b511e09ffc42cf563c344af483451")
+      Kakao.init("%VITE_KAKAO_JS_KEY%")
     </script>
   </head>
   <body>


### PR DESCRIPTION
## 변경
`index.html`에 하드코딩돼 있던 Kakao 키를 Vite의 HTML 환경 변수 치환(`%VITE_KAKAO_JS_KEY%`)으로 분리.

## 확인된 사항: 두 곳의 키가 서로 달랐음
| 위치 | 기존 값 |
|---|---|
| 지도 SDK `appkey` | `80d903717b077cbc441742dd63bffb7e` |
| `Kakao.init()` | `519b511e09ffc42cf563c344af483451` |

Kakao 앱 하나당 JavaScript 키는 하나이므로 두 값이 다른 것은 서로 다른 앱을 가리키고 있었다는 의미입니다.
요청에 따라 **`519b511e09ffc42cf563c344af483451`로 통일**했습니다.

## 환경 변수
`VITE_KAKAO_JS_KEY` — Vercel Production / Preview / Development 및 로컬 `.env.local`에 등록 완료.
(Kakao JavaScript 키는 클라이언트에 노출되는 공개 값이라 non-sensitive로 등록. 보호는 Kakao Developers의 도메인 허용 목록으로 이루어집니다.)

## 검증
- 로컬 프로덕션 빌드에서 `dist/index.html`의 두 위치 모두 실제 키로 치환됨, `%VITE_` 잔재 0건
- `vercel pull`로 프로덕션 환경 변수에서 값이 정상적으로 내려오는 것 확인

## 머지 후 확인 필요
지도 SDK 키가 `80d9...` → `519b...`로 바뀝니다. 해당 앱에 `mamma-mia.site` 도메인이 등록돼 있어야 지도가 정상 동작하므로, 배포 후 지도 렌더링을 확인하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn3WFctS711j4Y6JAc5UeR