### PR TITLE
fix: Kakao SDK 미로드 시 앱 전체가 죽는 문제 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,10 @@
       crossorigin="anonymous"
     ></script>
     <script>
-      Kakao.init("%VITE_KAKAO_JS_KEY%")
+      // SDK 로드가 차단되면 Kakao가 없어 이 스크립트에서 페이지 전체가 죽는다
+      if (typeof Kakao !== "undefined") {
+        Kakao.init("%VITE_KAKAO_JS_KEY%")
+      }
     </script>
   </head>
   <body>

--- a/src/hooks/useKakaoMapsReady.ts
+++ b/src/hooks/useKakaoMapsReady.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react"
+import * as Sentry from "@sentry/react"
+
+const POLL_INTERVAL = 100
+const LOAD_TIMEOUT = 10000
+
+/**
+ * 지도 SDK는 index.html에서 별도 스크립트로 불러오기 때문에
+ * 광고 차단기·네트워크 실패로 로드되지 않는 경우가 있다.
+ * 이때 전역 kakao를 그대로 참조하면 ReferenceError로 페이지 전체가 죽는다.
+ */
+const isKakaoMapsLoaded = () =>
+  typeof window !== "undefined" &&
+  Boolean((window as unknown as { kakao?: { maps?: unknown } }).kakao?.maps)
+
+const useKakaoMapsReady = () => {
+  const [isReady, setIsReady] = useState(isKakaoMapsLoaded)
+
+  useEffect(() => {
+    if (isReady) return
+
+    const startedAt = Date.now()
+    const timer = window.setInterval(() => {
+      if (isKakaoMapsLoaded()) {
+        window.clearInterval(timer)
+        setIsReady(true)
+        return
+      }
+
+      if (Date.now() - startedAt >= LOAD_TIMEOUT) {
+        window.clearInterval(timer)
+        Sentry.captureMessage("Kakao 지도 SDK 로드 실패", "error")
+      }
+    }, POLL_INTERVAL)
+
+    return () => window.clearInterval(timer)
+  }, [isReady])
+
+  return isReady
+}
+
+export default useKakaoMapsReady

--- a/src/pages/challenge/registration/_components/RestaurantSearchBottomSheet.tsx
+++ b/src/pages/challenge/registration/_components/RestaurantSearchBottomSheet.tsx
@@ -4,6 +4,7 @@ import { overlay } from "overlay-kit"
 import THEME from "@/constants/theme"
 import TYPOGRAPHY from "@/constants/typography"
 import useTextInput from "@/hooks/useTextInput"
+import useKakaoMapsReady from "@/hooks/useKakaoMapsReady"
 import SearchIcon from "../_assets/search.svg?react"
 import { useState, useEffect, useRef } from "react"
 
@@ -48,12 +49,13 @@ const RestaurantSearchBottomSheet = ({
   const [selectedRestaurant, setSelectedRestaurant] =
     useState<RestaurantSearchResult | null>(null)
   const placesServiceRef = useRef<kakao.maps.services.Places | null>(null)
+  const isKakaoMapsReady = useKakaoMapsReady()
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.kakao?.maps?.services) {
-      placesServiceRef.current = new kakao.maps.services.Places()
-    }
-  }, [])
+    if (!isKakaoMapsReady || !window.kakao?.maps?.services) return
+
+    placesServiceRef.current = new kakao.maps.services.Places()
+  }, [isKakaoMapsReady])
 
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()

--- a/src/pages/challenge/restaurant/_components/RestaurantLocationSection.tsx
+++ b/src/pages/challenge/restaurant/_components/RestaurantLocationSection.tsx
@@ -5,6 +5,7 @@ import kakaoMapImg from "../_assets/kakaomap_basic_1.webp"
 import { useEffect, useRef } from "react"
 import toast from "@/utils/toast"
 import { 충무로역_좌표 } from "@/pages/main/_constants"
+import useKakaoMapsReady from "@/hooks/useKakaoMapsReady"
 
 const RestaurantLocationSection = ({
   latitude,
@@ -17,9 +18,10 @@ const RestaurantLocationSection = ({
 }) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const kakaoMap = useRef<kakao.maps.Map | null>(null)
+  const isKakaoMapsReady = useKakaoMapsReady()
 
   useEffect(() => {
-    if (!mapRef.current) return
+    if (!mapRef.current || !isKakaoMapsReady) return
 
     var options = {
       //지도를 생성할 때 필요한 기본 옵션
@@ -82,7 +84,7 @@ const RestaurantLocationSection = ({
         </div>
       `,
     })
-  }, [])
+  }, [isKakaoMapsReady])
 
   return (
     <div css={locationSectionStyle}>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -10,12 +10,22 @@ import { useNavigate } from "react-router-dom"
 import toast from "@/utils/toast"
 import VIEWPORT from "@/constants/viewport"
 import { usePostSocialLoginMutation } from "@/hooks/@server/auth"
+import * as Sentry from "@sentry/react"
 
 const LoginPage = () => {
   const navigate = useNavigate()
   const { mutate: postSocialLogin } = usePostSocialLoginMutation()
 
   const handleKakaoLogin = () => {
+    // SDK 로드가 차단되면 Kakao가 없어 클릭 시 페이지가 죽는다
+    if (typeof Kakao === "undefined" || !Kakao.isInitialized?.()) {
+      toast({
+        message: "카카오 로그인을 불러오지 못했어요. 잠시 후 다시 시도해주세요.",
+      })
+      Sentry.captureMessage("Kakao JS SDK 로드 실패", "error")
+      return
+    }
+
     Kakao.Auth.authorize({
       redirectUri: `${window.location.origin}/login/oauth`,
     })

--- a/src/pages/main/_constants/index.ts
+++ b/src/pages/main/_constants/index.ts
@@ -19,14 +19,16 @@ export const 충무로역_좌표 = {
   lng: 126.9945,
 }
 
-export const 딤_영역 = [
+// 모듈 최상단에서 kakao 전역을 참조하면 SDK 로드 실패 시 import 시점에 앱 전체가 죽는다.
+// 지도 SDK 준비 이후에만 호출되도록 함수로 감싼다.
+export const get딤_영역 = () => [
   new kakao.maps.LatLng(0.0, 200.0),
   new kakao.maps.LatLng(200.0, 0.0),
   new kakao.maps.LatLng(200.0, 200.0),
   new kakao.maps.LatLng(0.0, 0.0),
 ]
 
-export const 서비스_영역 = [
+export const get서비스_영역 = () => [
   new kakao.maps.LatLng(37.570294707575194, 126.99218948837137),
   new kakao.maps.LatLng(37.57052912439423, 126.99513256445218),
   new kakao.maps.LatLng(37.570979706332714, 127.00194698594886),

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -14,15 +14,17 @@ import TopNavigation from "./_components/TopNavigation"
 import { useGetNearbyStoreQuery } from "@/hooks/@server/store"
 import VIEWPORT from "@/constants/viewport"
 import PopupToggleButton from "./_components/PopupToggleButton"
-import { 충무로역_좌표, 딤_영역, 서비스_영역 } from "./_constants"
+import { 충무로역_좌표, get딤_영역, get서비스_영역 } from "./_constants"
 import RestaurantListPopup from "./_components/RestaurantListPopup"
 import { AnimatePresence } from "motion/react"
 import MoveToMyLocationButton from "./_components/MoveToMyLocationButton"
 import RefetchOnCurrentPositionButton from "./_components/RefetchOnCurrentPositionButton"
 import CustomOverlayContent from "./_components/CustomOverlayContent"
 import MyLocationOverlayContent from "./_components/MyLocationOverlayContent"
+import useKakaoMapsReady from "@/hooks/useKakaoMapsReady"
 
 const MainPage = () => {
+  const isKakaoMapsReady = useKakaoMapsReady()
   const mapRef = useRef<HTMLDivElement>(null)
   const kakaoMap = useRef<kakao.maps.Map | null>(null)
   const swiperRef = useRef<SwiperRef>(null)
@@ -108,7 +110,7 @@ const MainPage = () => {
   }
 
   useEffect(() => {
-    if (!mapRef.current) return
+    if (!mapRef.current || !isKakaoMapsReady) return
 
     const hasInitialBounds = [
       searchParams.has("minLatitude"),
@@ -146,7 +148,7 @@ const MainPage = () => {
     })
 
     const polygon = new kakao.maps.Polygon({
-      path: [딤_영역, 서비스_영역],
+      path: [get딤_영역(), get서비스_영역()],
       strokeWeight: 1, // 선의 두께입니다
       strokeColor: THEME.COLORS.PRIMARY.RED, // 선의 색깔입니다
       strokeStyle: "solid", // 선의 스타일 입니다
@@ -171,7 +173,7 @@ const MainPage = () => {
         { isPopupOpen: false }
       )
     })
-  }, [])
+  }, [isKakaoMapsReady])
 
   useEffect(() => {
     if (!kakaoMap.current) return

--- a/src/pages/restaurant/_components/RestaurantLocationSection.tsx
+++ b/src/pages/restaurant/_components/RestaurantLocationSection.tsx
@@ -5,6 +5,7 @@ import kakaoMapImg from "../_assets/kakaomap_basic_1.webp"
 import { useEffect, useRef } from "react"
 import toast from "@/utils/toast"
 import { 충무로역_좌표 } from "@/pages/main/_constants"
+import useKakaoMapsReady from "@/hooks/useKakaoMapsReady"
 
 const RestaurantLocationSection = ({
   latitude,
@@ -17,9 +18,10 @@ const RestaurantLocationSection = ({
 }) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const kakaoMap = useRef<kakao.maps.Map | null>(null)
+  const isKakaoMapsReady = useKakaoMapsReady()
 
   useEffect(() => {
-    if (!mapRef.current) return
+    if (!mapRef.current || !isKakaoMapsReady) return
 
     var options = {
       //지도를 생성할 때 필요한 기본 옵션
@@ -82,7 +84,7 @@ const RestaurantLocationSection = ({
         </div>
       `,
     })
-  }, [])
+  }, [isKakaoMapsReady])
 
   return (
     <div css={locationSectionStyle}>


### PR DESCRIPTION
## 문제
Sentry에 잡히던 `ReferenceError: kakao is not defined` (MAMMA-MIA-FRONTEND-1/5)의 원인을 재현해서 찾았습니다.

`src/pages/main/_constants/index.ts`가 **모듈 최상단에서** `new kakao.maps.LatLng(...)`를 37번 호출합니다. 이는 import 시점에 즉시 평가되므로, 지도 SDK 로드가 실패하면 **컴포넌트가 렌더링되기도 전에** 터지고 루트에 ErrorBoundary가 없어 화면이 백지가 됩니다.

`index.html`의 스크립트가 프로토콜 상대 경로(`//dapi.kakao.com`)라 http 환경에서 재현되며, 실사용자에게는 광고 차단기나 네트워크 실패로 동일하게 발생합니다.

## 변경
- `딤_영역` / `서비스_영역`을 **지연 평가 함수**(`get딤_영역` / `get서비스_영역`)로 변경 — 실제 원인 수정
- `useKakaoMapsReady` 훅 추가: SDK 전역이 준비될 때까지 폴링하고, 준비되면 effect가 재실행되도록 게이팅 (메인 지도, 음식점/챌린지 상세 지도, 장소 검색)
- 10초 내 로드 실패 시 Sentry로 보고 — 이제 백지 대신 원인이 기록됨
- `index.html`의 `Kakao.init`과 카카오 로그인 핸들러에 전역 존재 여부 가드 추가 (로그인은 토스트 안내)

## 검증
로컬 프로덕션 빌드로 SDK가 로드되지 않는 상황을 재현해 비교했습니다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 화면 | 완전 백지 | 검색바·탭·버튼 등 UI 정상 렌더링 |
| 콘솔 | `ReferenceError: kakao is not defined` | 해당 에러 없음 |

지도 영역만 비고 나머지 기능은 살아 있는 상태로 degrade됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn3WFctS711j4Y6JAc5UeR